### PR TITLE
Update Dockerfile for golang 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM golang:1.8-alpine
+FROM golang:1.11-alpine
 
 WORKDIR /go/src/basic-go-server
 COPY . .
 
-RUN go-wrapper download
-RUN go-wrapper install
+RUN go install
 
 EXPOSE 8080
 
-CMD ["go-wrapper", "run"]
+CMD ["basic-go-server"]


### PR DESCRIPTION
I was just looking to update the version and noticed that the go-wrapper is not available in the 1.11 alpine image.  

This seems to work in a similar manner but please verify if you have time or interest in an update!